### PR TITLE
Updates to ryvencore API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,12 @@
 __pycache__/
 venv/
 temp/
-tests/
 code_gen/
 __own__/
 build/
 dist/
 *.egg-info
+tests/data
 
 ryvencore-drawio.xml
 

--- a/ryven/NENV.py
+++ b/ryven/NENV.py
@@ -25,8 +25,8 @@ def init_node_env():
     if os.environ['RYVEN_MODE'] == 'gui':
 
         from ryvencore_qt import \
-            NodeInputBP as NodeInputType_, \
-            NodeOutputBP as NodeOutputType_, \
+            NodeInputType as NodeInputType_, \
+            NodeOutputType as NodeOutputType_, \
             dtypes as dtypes_
         from ryven.main.nodes.NodeBase import NodeBase as Node_
 

--- a/ryven/NENV.py
+++ b/ryven/NENV.py
@@ -61,6 +61,7 @@ def init_node_env():
 
 
 from ryven.main.utils import load_from_file
+from ryvencore.Data import Data
 
 
 def import_widgets(origin_file: str, rel_file_path='widgets.py'):

--- a/ryven/NENV.py
+++ b/ryven/NENV.py
@@ -8,6 +8,7 @@ import os
 
 
 # types
+# TODO: refactor NodeBP names
 Node = None
 NodeInputBP = None
 NodeOutputBP = None
@@ -24,14 +25,14 @@ def init_node_env():
     if os.environ['RYVEN_MODE'] == 'gui':
 
         from ryvencore_qt import \
-            NodeInputBP as NodeInputBP_, \
-            NodeOutputBP as NodeOutputBP_, \
+            NodeInputBP as NodeInputType_, \
+            NodeOutputBP as NodeOutputType_, \
             dtypes as dtypes_
         from ryven.main.nodes.NodeBase import NodeBase as Node_
 
         Node = Node_
-        NodeInputBP = NodeInputBP_
-        NodeOutputBP = NodeOutputBP_
+        NodeInputBP = NodeInputType_
+        NodeOutputBP = NodeOutputType_
         dtypes = dtypes_
 
     else:
@@ -39,8 +40,8 @@ def init_node_env():
         # import sources directly from backend if not running in gui mode
         from ryvencore import \
             Node as _Node, \
-            NodeInputBP as NodeInputBP_, \
-            NodeOutputBP as NodeOutputBP_, \
+            NodeInputType as NodeInputType_, \
+            NodeOutputType as NodeOutputType_, \
             dtypes as dtypes_
 
         class NodeWrp(_Node):
@@ -54,8 +55,8 @@ def init_node_env():
                 super().__init__(params)
 
         Node = NodeWrp
-        NodeInputBP = NodeInputBP_
-        NodeOutputBP = NodeOutputBP_
+        NodeInputBP = NodeInputType_
+        NodeOutputBP = NodeOutputType_
         dtypes = dtypes_
 
 

--- a/ryven/NENV.py
+++ b/ryven/NENV.py
@@ -13,6 +13,7 @@ Node = None
 NodeInputBP = None
 NodeOutputBP = None
 dtypes = None
+Data = None
 
 
 def init_node_env():
@@ -20,20 +21,23 @@ def init_node_env():
     global NodeInputBP
     global NodeOutputBP
     global dtypes
+    global Data
 
 
     if os.environ['RYVEN_MODE'] == 'gui':
-
+        import ryvencore_qt
         from ryvencore_qt import \
             NodeInputType as NodeInputType_, \
             NodeOutputType as NodeOutputType_, \
-            dtypes as dtypes_
+            dtypes as dtypes_, \
+            Data as Data_
         from ryven.main.nodes.NodeBase import NodeBase as Node_
 
         Node = Node_
         NodeInputBP = NodeInputType_
         NodeOutputBP = NodeOutputType_
         dtypes = dtypes_
+        Data = Data_
 
     else:
 
@@ -42,7 +46,8 @@ def init_node_env():
             Node as _Node, \
             NodeInputType as NodeInputType_, \
             NodeOutputType as NodeOutputType_, \
-            dtypes as dtypes_
+            dtypes as dtypes_, \
+            Data as Data_
 
         class NodeWrp(_Node):
             """
@@ -58,10 +63,11 @@ def init_node_env():
         NodeInputBP = NodeInputType_
         NodeOutputBP = NodeOutputType_
         dtypes = dtypes_
+        Data = Data_
 
 
 from ryven.main.utils import load_from_file
-from ryvencore.Data import Data
+
 
 
 def import_widgets(origin_file: str, rel_file_path='widgets.py'):

--- a/ryven/gui/main_window.py
+++ b/ryven/gui/main_window.py
@@ -52,13 +52,13 @@ class MainWindow(QMainWindow):
         # SESSION
         self.session = rc.Session()
         if info_msgs_enabled:
-            self.session.info_messenger().enable(traceback=True)
+            self.session._info_messenger().enable(traceback=True)
         else:
-            self.session.info_messenger().disable()
+            self.session._info_messenger().disable()
 
-        self.session.flow_view_created.connect(self.script_created)
-        self.session.script_renamed.connect(self.script_renamed)
-        self.session.script_deleted.connect(self.script_deleted)
+        self.session.flow_view_created.connect(self.flow_created)
+        self.session.flow_renamed.connect(self.flow_renamed)
+        self.session.flow_deleted.connect(self.flow_deleted)
 
         # LOAD DESIGN AND FLOW THEME
         self.session.design.load_from_config(abs_path_from_package_dir('gui/styling/design_config.json'))
@@ -96,7 +96,7 @@ class MainWindow(QMainWindow):
         print('importing requested packages...')
         self.import_packages(requested_packages)
         if action == 'create project':
-            self.session.create_script(title='hello world')
+            self.session.create_flow(title='hello world')
         elif action == 'open project':
             print('importing required packages...')
             self.import_packages(required_packages)
@@ -136,7 +136,7 @@ CONTROLS
         # self.ui.left_vertical_splitter.setSizes([350, 350])
         self.ui.main_vertical_splitter.setSizes([700, 0])
 
-        self.scripts_list_widget = rc_GUI.ScriptsList(self.session)
+        self.scripts_list_widget = rc_GUI.FlowsList(self.session)
         self.ui.scripts_groupBox.layout().addWidget(self.scripts_list_widget)
 
         self.nodes_list_widget = rc_GUI.NodeListWidget(self.session)
@@ -294,7 +294,7 @@ CONTROLS
         new_script_title = GetTextDialog('choose unique title', '', 'new script title', self).get_text()
 
         if new_script_title not in (s.title for s in self.session.scripts):
-            self.session.create_script(new_script_title)
+            self.session.create_flow(new_script_title)
         else:
             script = [s for s in self.session.scripts if s.title == new_script_title][0]
             self.focus_on_script(script)
@@ -325,19 +325,19 @@ CONTROLS
 
     # SESSION
 
-    def script_created(self, script, flow_view):
+    def flow_created(self, script, flow_view):
         script_widget = ScriptUI(self, script, flow_view)
         self.script_UIs[script] = script_widget
         self.ui.scripts_tab_widget.addTab(script_widget, script.title)
         self.focus_on_script(script)
 
-    def script_renamed(self, script):
+    def flow_renamed(self, script):
         self.ui.scripts_tab_widget.setTabText(
             self.session.scripts.index(script),
             script.title
         )
 
-    def script_deleted(self, script):
+    def flow_deleted(self, script):
         self.ui.scripts_tab_widget.removeTab(self.ui.scripts_tab_widget.indexOf(self.script_UIs[script]))
         del self.script_UIs[script]
 

--- a/ryven/gui/script_UI.py
+++ b/ryven/gui/script_UI.py
@@ -55,10 +55,12 @@ class ScriptUI(QWidget):
         # logs
         self.ui.logs_scrollArea.setWidget(self.create_loggers_widget())
         self.ui.splitter.setSizes([700, 0])
-        self.script.logs_manager.new_logger_created.connect(self.add_logger_widget)
+
+        # TODO: need to connect to logging event but seems it isn't implemented yet
+        #self.flow.session.addons.get('Logging').logs_manager.new_logger_created.connect(self.add_logger_widget)
 
         # catch up on logs which might have been loaded from a project already
-        for logger in self.script.logs_manager.loggers:
+        for logger in self.flow.session.addons.get('Logging').loggers:
             self.add_logger_widget(logger)
 
 

--- a/ryven/gui/script_UI.py
+++ b/ryven/gui/script_UI.py
@@ -41,7 +41,7 @@ class ScriptUI(QWidget):
         # self.flow_vp_update_mode_changed(self.script.flow_view.viewport_update_mode())
 
         # variables list widget
-        self.vars_list_widget = GUI.VarsList(self.script.vars_manager)
+        self.vars_list_widget = GUI.VarsList(self.flow.session.addons.get('Variables'), self.flow) # TODO: how are vars now managed?
         self.ui.variables_group_box.layout().addWidget(self.vars_list_widget)
         self.ui.settings_vars_splitter.setSizes([40, 700])
 

--- a/ryven/gui/script_UI.py
+++ b/ryven/gui/script_UI.py
@@ -17,17 +17,17 @@ class ScriptUI(QWidget):
         FlowAlg.EXEC: 'exec-flow',
     }
 
-    def __init__(self, main_window, script, flow_view):
+    def __init__(self, main_window, flow, flow_view):
         super().__init__(main_window)
 
-        self.script = script
+        self.flow = flow
         self.flow_view = flow_view
         
         # UI
         self.ui = Ui_script_widget()
         self.ui.setupUi(self)
 
-        self.script.flow.algorithm_mode_changed.connect(self.flow_alg_mode_changed)
+        self.flow.algorithm_mode_changed.connect(self.flow_alg_mode_changed)
         # self.script.flow_view.viewport_update_mode_changed.connect(self.flow_vp_update_mode_changed)
 
         self.flow_alg_mode_dropdown = QComboBox()
@@ -37,7 +37,7 @@ class ScriptUI(QWidget):
         self.flow_alg_mode_dropdown.currentTextChanged.connect(self.flow_algorithm_mode_toggled)
 
         # catch up on flow modes
-        self.flow_alg_mode_changed(self.script.flow.algorithm_mode())
+        self.flow_alg_mode_changed(self.flow.algorithm_mode())
         # self.flow_vp_update_mode_changed(self.script.flow_view.viewport_update_mode())
 
         # variables list widget

--- a/ryven/main/RyvenConsole.py
+++ b/ryven/main/RyvenConsole.py
@@ -127,38 +127,8 @@ def run():
     c = ContextContainer()
     setattr(c, 'session', session)
 
-    #
-    # LOAD PROJECT AND NODE PACKAGES -----------------------------------------------------------------------------------
-    #
-
-    # check if project file exists
-    project = find_project(args.project[0])
-    if project is None:
-        sys.exit('Could not find specified project.')
-
-    # process node packages
-    manual_nodes, _, _ = process_nodes_packages(args.nodes)
-
-    node_packages, nodes_not_found, project_dict = process_nodes_packages(
-        project, requested_nodes=manual_nodes,
-    )
-
-    if nodes_not_found:
-        mul = len(nodes_not_found) > 1  # multiple packages missing ?
-        sys.exit(
-            f'The package{"s" if mul else ""} '
-            f''''{"', '".join([str(p) for p in nodes_not_found])}' '''
-            f'{"were" if mul else "was"} requested, '
-            f'but {"they are" if mul else "it is"} not available.'
-            f'\n'
-            f'Update the project file or supply the missing package{"s" if mul else ""} '
-            f''''{"', '".join([p.name for p in nodes_not_found])}' '''
-            f'on the command line with the "-n" switch.')
-
-    for np in node_packages:
-        import_nodes(session, c, np)
-
-    load_project(session, c, project)
+    # What happens here and underneath needs to be refactored for clarity
+    load_project_and_nodes(args.project[0], args.nodes, c, session)
 
     #
     # DEPLOY REPL ------------------------------------------------------------------------------------------------------
@@ -205,6 +175,35 @@ def run():
 
     except:
         sys.exit('exiting...')
+
+
+def load_project_and_nodes(project_path, nodes, c, session):
+    #
+    # LOAD PROJECT AND NODE PACKAGES -----------------------------------------------------------------------------------
+    #
+    # check if project file exists
+    project = find_project(project_path)
+    if project is None:
+        sys.exit('Could not find specified project.')
+    # process node packages
+    manual_nodes, _, _ = process_nodes_packages(nodes)
+    node_packages, nodes_not_found, project_dict = process_nodes_packages(
+        project, requested_nodes=manual_nodes,
+    )
+    if nodes_not_found:
+        mul = len(nodes_not_found) > 1  # multiple packages missing ?
+        sys.exit(
+            f'The package{"s" if mul else ""} '
+            f''''{"', '".join([str(p) for p in nodes_not_found])}' '''
+            f'{"were" if mul else "was"} requested, '
+            f'but {"they are" if mul else "it is"} not available.'
+            f'\n'
+            f'Update the project file or supply the missing package{"s" if mul else ""} '
+            f''''{"', '".join([p.name for p in nodes_not_found])}' '''
+            f'on the command line with the "-n" switch.')
+    for np in node_packages:
+        import_nodes(session, c, np)
+    load_project(session, c, project)
 
 
 if __name__ == '__main__':

--- a/ryven/main/nodes/built_in/nodes.py
+++ b/ryven/main/nodes/built_in/nodes.py
@@ -106,7 +106,7 @@ class Val_Node(NodeBase):
 
     def update_event(self, input_called=-1):
         self.val = self.input(0)
-        self.set_output_val(0, self.val)
+        self.set_output_val(0, Data(self.val))
 
     def action_edit_via_dialog(self):
         return

--- a/ryven/main/nodes/built_in/nodes.py
+++ b/ryven/main/nodes/built_in/nodes.py
@@ -85,7 +85,7 @@ class Val_Node(NodeBase):
 
     title = 'val'
     init_inputs = [
-        NodeInputBP(),
+        NodeInputBP(default=Data()),
     ]
     init_outputs = [
         NodeInputBP(type_='data'),
@@ -98,7 +98,7 @@ class Val_Node(NodeBase):
 
         self.display_title = ''
         self.actions['edit val via dialog'] = {'method': self.action_edit_via_dialog}
-        self.val = None
+        self.val = Data()
 
 
     def place_event(self):
@@ -106,7 +106,7 @@ class Val_Node(NodeBase):
 
     def update_event(self, input_called=-1):
         self.val = self.input(0)
-        self.set_output_val(0, Data(self.val))
+        self.set_output_val(0, self.val)
 
     def action_edit_via_dialog(self):
         return

--- a/ryven/main/nodes/built_in/nodes.py
+++ b/ryven/main/nodes/built_in/nodes.py
@@ -13,7 +13,7 @@ class GetVar_Node(NodeBase):
 
     title = 'get var'
     init_inputs = [
-        NodeInputBP(dtype=dtypes.String(size='m')),
+        NodeInputBP(),
     ]
     init_outputs = [
         NodeOutputBP(label='val')
@@ -85,7 +85,7 @@ class Val_Node(NodeBase):
 
     title = 'val'
     init_inputs = [
-        NodeInputBP(dtype=dtypes.Data(size='s')),
+        NodeInputBP(),
     ]
     init_outputs = [
         NodeInputBP(type_='data'),
@@ -150,8 +150,8 @@ class SetVar_Node(NodeBase):
     title = 'set var'
     init_inputs = [
         NodeInputBP(type_='exec'),
-        NodeInputBP(dtype=dtypes.String(), label='var'),
-        NodeInputBP(dtype=dtypes.Data(size='s'), label='val'),
+        NodeInputBP(label='var'),
+        NodeInputBP(label='val'),
     ]
     init_outputs = [
         NodeOutputBP(type_='exec'),

--- a/ryven/main/utils.py
+++ b/ryven/main/utils.py
@@ -83,9 +83,9 @@ def import_nodes_package(package: NodesPackage = None, directory: str = None) ->
 
     # add package name to identifiers and define custom types
 
-    for n in nodes:
-        n.identifier_prefix = package.name  #  + '.' + (n.identifier if n.identifier else n.__name__)
-        n.type_ = package.name if not n.type_ else f'{package.name}[{n.type_}]'
+    # for n in nodes:
+    #     n.identifier_prefix = package.name  #  + '.' + (n.identifier if n.identifier else n.__name__)
+    #     n.type_ = package.name if not n.type_ else f'{package.name}[{n.type_}]'
 
     return nodes
 

--- a/ryven/main/utils.py
+++ b/ryven/main/utils.py
@@ -223,6 +223,9 @@ def process_nodes_packages(project_or_nodes, requested_nodes=[]):
     except TypeError:
         project_dict = None
         nodes = project_or_nodes
+    except KeyError:
+        # No required packages found
+        nodes = []
 
     node_packages = set()
     nodes_not_found = set()

--- a/tests/built_in_nodes.py
+++ b/tests/built_in_nodes.py
@@ -1,0 +1,30 @@
+import unittest
+from os.path import join, dirname
+import os
+import unittest
+from os.path import join, dirname
+
+import ryvencore as rc
+from ryven.NENV import init_node_env
+from ryven.main.nodes_package import NodesPackage
+from ryven.main.utils import import_nodes_package
+
+
+class BuiltInNodesTestCase(unittest.TestCase):
+
+    def test_load_builtin_nodes(self):
+        os.environ['RYVEN_MODE'] = 'no-gui'
+        init_node_env()
+        session = rc.Session(gui=False)
+        nodes=import_nodes_package(
+                NodesPackage(
+                    directory=join(dirname(__file__), '../ryven/main/nodes/built_in/')
+                )
+            )
+        session.register_nodes(nodes)
+        print('registered nodes: ', nodes)
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/console.py
+++ b/tests/console.py
@@ -1,0 +1,38 @@
+import json
+import unittest
+
+import ryvencore as rc
+from ryven.main.RyvenConsole import load_project_and_nodes
+
+
+class RyvenConsoleTestCase(unittest.TestCase):
+    # This class tests the working of the underlying methods used by RyvenConsole, i.e. that do not use
+    # the GUI elements of Ryven.
+
+    def test_load_empty_flow(self):
+        # Create empty flow
+        rc.Base.Base._global_id_ctr.ctr = -1
+        session = rc.Session()
+        session.create_flow('main')
+        serialize = session.serialize()
+        json_string = json.dumps(serialize)
+        del session
+
+        test_data_path = ".\\data\\test.json"
+        with open(test_data_path, "w") as f:
+            # Writing data to a file
+            f.write(json_string)
+
+        # Given how the Global IDs work (they are re-generated every time an object is created)
+        # we reset the counter manually to ensure the IDs are the same
+        rc.Base.Base._global_id_ctr.ctr = -1
+
+        # Reload file
+        session = rc.Session()
+        load_project_and_nodes(test_data_path, [], None, session)
+
+        self.assertEqual(serialize, session.serialize())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Following discussion in #126 this allows Ryven and ryvencore-qt to use the current dev branch of ryvencore. I implemented the ryvencore API changes (removal of Script, connections, view_place_event, load_data), updated the widgets and wrappers and fixed references to the addons so that Ryven can start and one is able to drop new nodes (tested only with Val and Results).
This is a first step, and will require some more work as connections don't fully work yet, to see if you're okay with the direction.
There's a few open questions:
- The input widgets now don't have an object to store a value in (only output ports do so in the new ryvencore), so this is where I stopped. I was thinking this may be the moment to completely remove the input widgets, and store all the interactivity in the main Node widget. 
- I think I didn't follow your logic for imports, which would in any case benefit from some clarification/simplification. 
- Pushing the simplification thinking, I also wonder what use case there is for the Console in Ryven? This is what drives some complexity in the imports, and I'm not sure who would use that very bare-bones execution mode.
