### PR TITLE
Resolve Issue with multiple QT backends

### DIFF
--- a/ryven-editor/ryven/main/Ryven.py
+++ b/ryven-editor/ryven/main/Ryven.py
@@ -63,19 +63,21 @@ def run(*args_,
     -------
     None|Main Window
     """
-
+                
+    # Process command line and method's arguments
+    # QT_API environment is set in config.py now. If other qt Backends are installed "from ryven.gui_env import init_node_guis_env" and the static method get_available_flow_themes() from config.py can throw errors if the environment is not set before!
+    conf: Config = process_args(use_sysargs, *args_, **kwargs)
+                
     from ryven.node_env import init_node_env
     from ryven.gui_env import init_node_guis_env    # Qt dependency
-
-    # Process command line and method's arguments
-    conf: Config = process_args(use_sysargs, *args_, **kwargs)
-
+                
     #
     # Qt application setup
     #
 
-    # QtPy API
-    os.environ['QT_API'] = conf.qt_api
+    # QtPy API 
+    # !!! Temporarily moved into config.py !!!
+    # os.environ['QT_API'] = conf.qt_api
 
     # Init environment
     os.environ['RYVEN_MODE'] = 'gui'

--- a/ryven-editor/ryven/main/config.py
+++ b/ryven-editor/ryven/main/config.py
@@ -38,7 +38,7 @@ class Config:
     window_geometry: Optional[str] = None
     window_title: str = 'Ryven'
     qt_api: str = 'pyside2'
-    os.environ['QT_API'] = self.qt_api
+    os.environ['QT_API'] = qt_api
     src_code_edits_enabled: bool = False
 
     @staticmethod

--- a/ryven-editor/ryven/main/config.py
+++ b/ryven-editor/ryven/main/config.py
@@ -1,4 +1,5 @@
 import pathlib
+import os
 from typing import Optional, Literal, List, Dict, Set, Union
 
 from ryven import NodesPackage
@@ -37,6 +38,7 @@ class Config:
     window_geometry: Optional[str] = None
     window_title: str = 'Ryven'
     qt_api: str = 'pyside2'
+    os.environ['QT_API'] = self.qt_api
     src_code_edits_enabled: bool = False
 
     @staticmethod


### PR DESCRIPTION
As written in the Issues, when installing Matplotlib, I get some qt related errors.

I think the issue is that qtpy does not choose pyside2 by default so when pyqt5 gets installed because of matplotlib, pyqt5 is chosen unless the environment variable is different.

Right now in the code 

`from ryven.gui_env import init_node_guis_env`

from Ryven.py

and

`from ryvencore_qt.src.Design import Design`

from config.py get called before the environment variable is set.

Right now the choice for the QT_API is in the config.py. And the first call is also in config.py.  This leaves two options to fix this:

either set the QT_API environment variable before loading the config. (In that case the qt_api value of the config would be useless)

or set the environment variable in config.py (also not ideal to do this in a config class)

I went with the latter approach for this pull request and made sure the config is loaded before init_node_guis_env is imported