### PR TITLE
Decorator for Node GUIs and GUI deferred loading

### DIFF
--- a/ryven-editor/ryven/api.py
+++ b/ryven-editor/ryven/api.py
@@ -1,0 +1,2 @@
+from ryven.node_env import *
+from ryven.gui_env import *

--- a/ryven-editor/ryven/api.py
+++ b/ryven-editor/ryven/api.py
@@ -1,3 +1,0 @@
-from ryven.node_env import *
-from ryven.gui_env import *
-from ryven.main.utils import in_gui_mode

--- a/ryven-editor/ryven/api.py
+++ b/ryven-editor/ryven/api.py
@@ -1,2 +1,3 @@
 from ryven.node_env import *
 from ryven.gui_env import *
+from ryven.main.utils import in_gui_mode

--- a/ryven-editor/ryven/example_nodes/pkg_test/linalg/gui.py
+++ b/ryven-editor/ryven/example_nodes/pkg_test/linalg/gui.py
@@ -4,7 +4,7 @@ from qtpy.QtWidgets import QTextEdit
 from qtpy.QtGui import QFontMetrics
 
 import numpy as np
-
+from .nodes import *
 
 class MatrixWidget(NodeMainWidget, QTextEdit):
 
@@ -141,7 +141,7 @@ class EditMatrixWidget(MatrixWidget):
         self.update_matrix(self.node.expression_matrix)
         QTextEdit.focusOutEvent(self, e)
 
-
+@node_gui(MatrixNodeBase)
 class MatrixNodeBaseGui(NodeGUI):
     main_widget_class = MatrixWidget
     main_widget_pos = 'below ports'
@@ -185,14 +185,8 @@ class MatrixNodeBaseGui(NodeGUI):
             self.ac_hide_mw()
         # shown by default
 
-
+@node_gui(EditMatrixNode)
 class EditMatrixNodeGui(MatrixNodeBaseGui):
     main_widget_class = EditMatrixWidget
     main_widget_pos = 'below ports'
     color = '#3344ff'
-
-
-export_guis([
-    MatrixNodeBaseGui,
-    EditMatrixNodeGui,
-])

--- a/ryven-editor/ryven/example_nodes/pkg_test/linalg/nodes.py
+++ b/ryven-editor/ryven/example_nodes/pkg_test/linalg/nodes.py
@@ -3,7 +3,6 @@ from typing import Optional, List
 import ryvencore.addons.Variables
 
 from ryven.node_env import *
-guis = import_guis(__file__)
 
 import numpy as np
 from itertools import chain
@@ -33,7 +32,6 @@ class MatrixNodeBase(Node):
     init_outputs = [
         NodeOutputType()
     ]
-    GUI = guis.MatrixNodeBaseGui
 
     def __init__(self, params):
         super().__init__(params)
@@ -304,7 +302,6 @@ class EditMatrixNode(Node):
     init_outputs = [
         NodeOutputType()
     ]
-    GUI = guis.EditMatrixNodeGui
 
     def __init__(self, params):
         super().__init__(params)
@@ -464,3 +461,4 @@ export_sub_nodes(__file__,
 ],
     data_types=[MatrixData]
 )
+

--- a/ryven-editor/ryven/example_nodes/pkg_test/nodes.py
+++ b/ryven-editor/ryven/example_nodes/pkg_test/nodes.py
@@ -1,2 +1,10 @@
+import os
+from ryven.api import on_gui_load
+
 from .std import nodes
 from .linalg import nodes
+
+@on_gui_load
+def load_gui():
+    from .std import gui
+    from .linalg import gui

--- a/ryven-editor/ryven/example_nodes/pkg_test/nodes.py
+++ b/ryven-editor/ryven/example_nodes/pkg_test/nodes.py
@@ -1,5 +1,4 @@
-import os
-from ryven.api import on_gui_load
+from ryven.node_env import on_gui_load
 
 from .std import nodes
 from .linalg import nodes

--- a/ryven-editor/ryven/example_nodes/pkg_test/std/basic_operators.py
+++ b/ryven-editor/ryven/example_nodes/pkg_test/std/basic_operators.py
@@ -1,7 +1,4 @@
-from ryven.node_env import *
-
-guis = import_guis(__file__)
-
+from ryvencore import Node, NodeInputType, NodeOutputType, Data
 
 class OperatorNodeBase(Node):
     """
@@ -16,8 +13,7 @@ class OperatorNodeBase(Node):
     init_outputs = [
         NodeOutputType(),
     ]
-    GUI = guis.OperatorNodeBaseGui
-
+    
     def __init__(self, params):
         super().__init__(params)
 
@@ -50,8 +46,7 @@ class OperatorNodeBase(Node):
 
 
 class LogicNodeBase(OperatorNodeBase):
-    GUI = guis.LogicNodeBaseGui
-
+    pass
 
 class NOT_Node(LogicNodeBase):
     title = 'not'
@@ -123,7 +118,7 @@ logic_nodes = [
 
 
 class ArithmeticNodeBase(OperatorNodeBase):
-    GUI = guis.ArithNodeBaseGui
+    pass
 
 
 class Plus_Node(ArithmeticNodeBase):
@@ -194,7 +189,6 @@ arithmetic_nodes = [
 
 
 class ComparatorNodeBase(OperatorNodeBase):
-    GUI = guis.CompNodeBaseGui
 
     def apply_op(self, elements: list):
         # if len(elements) > 0:

--- a/ryven-editor/ryven/example_nodes/pkg_test/std/control_structures.py
+++ b/ryven-editor/ryven/example_nodes/pkg_test/std/control_structures.py
@@ -1,12 +1,8 @@
-from ryven.node_env import *
-
-guis = import_guis(__file__)
-
+from ryvencore import Node, NodeInputType, NodeOutputType, Data
 
 class CSNodeBase(Node):
     version = 'v0.2'
-    GUI = guis.CSNodeBaseGui
-
+    
 class If_Node(CSNodeBase):
     title = 'branch'
     init_inputs = [
@@ -40,8 +36,7 @@ class ForLoop_Node(CSNodeBase):
         NodeOutputType('i', type_='data'),
         NodeOutputType('finished', type_='exec'),
     ]
-    GUI = guis.ForLoopGui
-
+    
     def __init__(self, params):
         super().__init__(params)
 
@@ -103,7 +98,6 @@ class ForEachLoop_Node(CSNodeBase):
         NodeOutputType('e', type_='data'),
         NodeOutputType('finished', type_='exec'),
     ]
-    GUI = guis.ForEachLoopGui
 
     def update_event(self, inp=-1):
         for e in self.input(0).payload:

--- a/ryven-editor/ryven/example_nodes/pkg_test/std/gui.py
+++ b/ryven-editor/ryven/example_nodes/pkg_test/std/gui.py
@@ -2,7 +2,9 @@ import re
 
 from ryven.gui_env import *
 
-from special_nodes import *
+from .special_nodes import *
+from .control_structures import *
+from .basic_operators import *
 
 from qtpy.QtGui import QFont
 from qtpy.QtCore import Qt, Signal, QEvent
@@ -14,7 +16,6 @@ from qtpy.QtWidgets import QPushButton, QComboBox, QSlider, QTextEdit, QPlainTex
     generic base classes
 """
 
-
 class GuiBase(NodeGUI):
     pass
 
@@ -23,7 +24,7 @@ class GuiBase(NodeGUI):
     operator nodes
 """
 
-
+@node_gui(OperatorNodeBase)
 class OperatorNodeBaseGui(GuiBase):
     input_widget_classes = {
         'in': inp_widgets.Builder.evaled_line_edit(size='s', resizing=True),
@@ -67,15 +68,15 @@ class OperatorNodeBaseGui(GuiBase):
             self.actions[f'remove input'][f'{i}'] = \
                 {'method': self.remove_operand_input, 'data': i}
 
-
+@node_gui(LogicNodeBase)
 class LogicNodeBaseGui(OperatorNodeBaseGui):
     color = '#f58142'
 
-
+@node_gui(ArithmeticNodeBase)
 class ArithNodeBaseGui(OperatorNodeBaseGui):
     color = '#58db53'
 
-
+@node_gui(ComparatorNodeBase)
 class CompNodeBaseGui(OperatorNodeBaseGui):
     color = '#a1574c'
 
@@ -84,12 +85,12 @@ class CompNodeBaseGui(OperatorNodeBaseGui):
     control structures
 """
 
-
+@node_gui(CSNodeBase)
 class CSNodeBaseGui(GuiBase):
     style = 'normal'
     color = '#b33a27'
 
-
+@node_gui(ForLoop_Node)
 class ForLoopGui(CSNodeBaseGui):
     input_widget_classes = {
         'RangeFrom': inp_widgets.Builder.int_spinbox(0, (0, 1000000)),
@@ -126,7 +127,7 @@ class ForLoopGui(CSNodeBaseGui):
             self.actions[f'remove dimension'][f'{i + 1}'] = \
                 {'method': self.remove_dimension, 'data': i + 1}
 
-
+@node_gui(ForEachLoop_Node)
 class ForEachLoopGui(CSNodeBaseGui):
     input_widget_classes = {
         'List': inp_widgets.Builder.evaled_line_edit(),
@@ -140,11 +141,11 @@ class ForEachLoopGui(CSNodeBaseGui):
     special nodes
 """
 
-
+@node_gui(NodeBase)
 class SpecialNodeGuiBase(GuiBase):
     color = '#FFCA00'
 
-
+@node_gui(DualNodeBase)
 class DualNodeBaseGui(SpecialNodeGuiBase):
     def initialized(self):
         super().initialized()
@@ -171,7 +172,7 @@ class DualNodeBaseGui(SpecialNodeGuiBase):
         self.actions['make passive'] = {'method': self.make_passive}
         self.node.make_active()
 
-
+@node_gui(Checkpoint_Node)
 class CheckpointNodeGui(DualNodeBaseGui):
     style = 'small'
     display_title = ''
@@ -205,7 +206,7 @@ class ButtonNode_MainWidget(QPushButton, NodeMainWidget):
 
         self.clicked.connect(self.update_node)
 
-
+@node_gui(Button_Node)
 class ButtonNodeGui(SpecialNodeGuiBase):
     main_widget_class = ButtonNode_MainWidget
     main_widget_pos = 'between ports'
@@ -220,7 +221,7 @@ class ClockNode_MainWidget(NodeMainWidget, QPushButton):
 
         self.clicked.connect(self.node.toggle)
 
-
+@node_gui(Clock_Node)
 class ClockNodeGui(SpecialNodeGuiBase):
     main_widget_class = ClockNode_MainWidget
     main_widget_pos = 'below ports'
@@ -246,7 +247,7 @@ class ClockNodeGui(SpecialNodeGuiBase):
     def stop(self):
         self.node.stop()
 
-
+@node_gui(Log_Node)
 class LogNodeGui(SpecialNodeGuiBase):
     color = '#5d95de'
 
@@ -264,7 +265,7 @@ class SliderNode_MainWidget(NodeMainWidget, QSlider):
         self.node.val = v/1000
         self.update_node()
 
-
+@node_gui(Slider_Node)
 class SliderNodeGui(SpecialNodeGuiBase):
     main_widget_class = SliderNode_MainWidget
     main_widget_pos = 'below ports'
@@ -280,7 +281,7 @@ class SliderNodeGui(SpecialNodeGuiBase):
     def initialized(self):
         self.main_widget().setValue(self.node.val*1000)
 
-
+@node_gui(DynamicPorts_Node)
 class DynamicPortsGui(SpecialNodeGuiBase):
     def __init__(self, params):
         super().__init__(params)
@@ -333,7 +334,7 @@ class ExecNode_MainWidget(NodeMainWidget, QTextEdit):
     def set_state(self, data: dict):
         self.setPlainText(data['text'])
 
-
+@node_gui(Exec_Node)
 class ExecNodeGui(DynamicPortsGui):
     main_widget_class = ExecNode_MainWidget
     main_widget_pos = 'between ports'
@@ -361,7 +362,7 @@ class EvalNode_MainWidget(NodeMainWidget, QPlainTextEdit):
     def set_state(self, data: dict):
         self.setPlainText(data['text'])
 
-
+@node_gui(Eval_Node)
 class EvalNodeGui(SpecialNodeGuiBase):
     main_widget_class = EvalNode_MainWidget
     main_widget_pos = 'between ports'
@@ -482,12 +483,12 @@ class ConsoleOutDisplay(QPlainTextEdit):
         self.setReadOnly(True)
         self.setFont(QFont('Source Code Pro', 9))
 
-
+@node_gui(Interpreter_Node)
 class InterpreterConsoleGui(SpecialNodeGuiBase):
     main_widget_class = InterpreterConsole
     main_widget_pos = 'between ports'
 
-
+@node_gui(Storage_Node)
 class StorageNodeGui(SpecialNodeGuiBase):
     color = '#aadd55'
 
@@ -499,7 +500,7 @@ class StorageNodeGui(SpecialNodeGuiBase):
     def clear(self):
         self.node.clear()
 
-
+@node_gui(LinkIN_Node)
 class LinkIN_NodeGui(SpecialNodeGuiBase):
     def __init__(self, params):
         super().__init__(params)
@@ -524,7 +525,7 @@ class LinkIN_NodeGui(SpecialNodeGuiBase):
         self.node.remove_input(index)
         del self.actions['remove inp'][str(index)]
 
-
+@node_gui(LinkOUT_Node)
 class LinkOUT_NodeGui(SpecialNodeGuiBase):
 
     class IDInpDialog(QDialog):

--- a/ryven-editor/ryven/example_nodes/pkg_test/std/nodes.py
+++ b/ryven-editor/ryven/example_nodes/pkg_test/std/nodes.py
@@ -1,13 +1,8 @@
 from ryven.node_env import *
-# widgets = import_gui(__file__)
 
-import sys
-import os
-sys.path.append(os.path.dirname(__file__))
-
-from special_nodes import nodes as special_nodes
-from basic_operators import nodes as operator_nodes
-from control_structures import nodes as cs_nodes
+from .special_nodes import nodes as special_nodes
+from .basic_operators import nodes as operator_nodes
+from .control_structures import nodes as cs_nodes
 
 export_sub_nodes(__file__,
     [*special_nodes,

--- a/ryven-editor/ryven/example_nodes/pkg_test/std/special_nodes.py
+++ b/ryven-editor/ryven/example_nodes/pkg_test/std/special_nodes.py
@@ -3,14 +3,10 @@ from contextlib import redirect_stdout, redirect_stderr
 from packaging.version import Version
 
 from ryvencore.addons.Logging import LoggingAddon
-from ryven.node_env import *
-
-guis = import_guis(__file__)
-
+from ryvencore.Node import Node, NodeOutputType, NodeInputType, Data
 
 class NodeBase(Node):
     version = 'v0.2'
-    GUI = guis.SpecialNodeGuiBase
 
     def have_gui(self):
         return hasattr(self, 'gui')
@@ -18,8 +14,6 @@ class NodeBase(Node):
 
 class DualNodeBase(NodeBase):
     """For nodes that can be active and passive"""
-
-    GUI = guis.DualNodeBaseGui
 
     def __init__(self, params, active=True):
         super().__init__(params)
@@ -55,7 +49,6 @@ class Checkpoint_Node(DualNodeBase):
     init_outputs = [
         NodeOutputType(type_='data'),
     ]
-    GUI = guis.CheckpointNodeGui
 
     def __init__(self, params):
         super().__init__(params)
@@ -117,7 +110,6 @@ class Button_Node(NodeBase):
     init_outputs = [
         NodeOutputType(type_='exec')
     ]
-    GUI = guis.ButtonNodeGui
 
     def update_event(self, inp=-1):
         self.exec_output(0)
@@ -153,7 +145,6 @@ class Log_Node(DualNodeBase):
     init_outputs = [
         NodeOutputType(type_='exec'),
     ]
-    GUI = guis.LogNodeGui
 
     logs = {}   # {int: Logger}
     in_use = set()  # make sure we don't reuse numbers on copy & paste
@@ -215,7 +206,6 @@ class Clock_Node(NodeBase):
     init_outputs = [
         NodeOutputType(type_='exec')
     ]
-    GUI = guis.ClockNodeGui
 
     # When running with GUI, this node uses QTime which doesn't
     # block the GUI. When running without GUI, it uses time.sleep()
@@ -282,7 +272,6 @@ class Slider_Node(NodeBase):
     init_outputs = [
         NodeOutputType(),
     ]
-    GUI = guis.SliderNodeGui
 
     def __init__(self, params):
         super().__init__(params)
@@ -305,10 +294,9 @@ class Slider_Node(NodeBase):
         self.val = data['val']
 
 
-class _DynamicPorts_Node(NodeBase):
+class DynamicPorts_Node(NodeBase):
     init_inputs = []
     init_outputs = []
-    GUI = guis.DynamicPortsGui
 
     def add_input(self):
         self.create_input()
@@ -323,9 +311,8 @@ class _DynamicPorts_Node(NodeBase):
         self.delete_output(index)
 
 
-class Exec_Node(_DynamicPorts_Node):
+class Exec_Node(DynamicPorts_Node):
     title = 'exec'
-    GUI = guis.ExecNodeGui
 
     def __init__(self, params):
         super().__init__(params)
@@ -354,7 +341,6 @@ class Eval_Node(NodeBase):
     init_outputs = [
         NodeOutputType(),
     ]
-    GUI = guis.EvalNodeGui
 
     def __init__(self, params):
         super().__init__(params)
@@ -401,7 +387,6 @@ class Interpreter_Node(NodeBase):
     title = 'interpreter'
     init_inputs = []
     init_outputs = []
-    GUI = guis.InterpreterConsoleGui
 
     """
     commands
@@ -475,7 +460,6 @@ class Storage_Node(NodeBase):
     init_outputs = [
         NodeOutputType(),
     ]
-    GUI = guis.StorageNodeGui
 
     def __init__(self, params):
         super().__init__(params)
@@ -516,7 +500,6 @@ class LinkIN_Node(NodeBase):
         NodeInputType(),
     ]
     init_outputs = []  # no outputs
-    GUI = guis.LinkIN_NodeGui
 
     # instances registration
     INSTANCES = {}  # {UUID: node}
@@ -577,7 +560,6 @@ class LinkOUT_Node(NodeBase):
     title = 'link OUT'
     init_inputs = []  # no inputs
     init_outputs = []  # will be synchronized with linked IN node
-    GUI = guis.LinkOUT_NodeGui
 
     INSTANCES = []
     PENDING_LINK_BUILDS = {}

--- a/ryven-editor/ryven/gui/main_window.py
+++ b/ryven-editor/ryven/gui/main_window.py
@@ -52,7 +52,7 @@ class MainWindow(QMainWindow):
         self.session_gui, self.core_session = None, None
         self.theme = config.window_theme
         self.node_packages = {}  # {Node: str}
-        self.flow_UIs: dict[Flow, FlowUI] = {}
+        self.flow_UIs = {}  # Should be dict[Flow, FlowUI] in 3.9+
         self.flow_ui_template: dict[str, QByteArray] = None
         self._project_content = None
 

--- a/ryven-editor/ryven/gui/main_window.py
+++ b/ryven-editor/ryven/gui/main_window.py
@@ -53,7 +53,7 @@ class MainWindow(QMainWindow):
         self.theme = config.window_theme
         self.node_packages = {}  # {Node: str}
         self.flow_UIs = {}  # Should be dict[Flow, FlowUI] in 3.9+
-        self.flow_ui_template: dict[str, QByteArray] = None
+        self.flow_ui_template = None # Should be dict[str, QByteArray] in 3.9+
         self._project_content = None
 
         # Init Session GUI

--- a/ryven-editor/ryven/main/packages/built_in/gui.py
+++ b/ryven-editor/ryven/main/packages/built_in/gui.py
@@ -1,7 +1,7 @@
 from ryvencore import Data
 
 from ryven.gui_env import *
-
+from .nodes import *
 from qtpy.QtGui import QKeySequence
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QLineEdit, QDialog, QDialogButtonBox, QMessageBox, QPlainTextEdit, QShortcut, QVBoxLayout
@@ -20,7 +20,7 @@ class Result_Node_MainWidget(NodeMainWidget, QLineEdit):
         self.setText(str(new_val))
         self.setCursorPosition(0)
 
-
+@node_gui(Result_Node)
 class ResultGui(NodeGUI):
     main_widget_class = Result_Node_MainWidget
     main_widget_pos = 'between ports'
@@ -108,7 +108,7 @@ class EditVal_Dialog(QDialog):
             pass
         return val
 
-
+@node_gui(Val_Node)
 class ValGui(NodeGUI):
     main_widget_class = ValNode_MainWidget
     style = 'small'
@@ -129,7 +129,7 @@ class ValGui(NodeGUI):
             self.main_widget().setText(str(val_dialog.get_val()))
             self.update()
 
-
+@node_gui(SetVarsPassive_Node)
 class SetVarsGui(NodeGUI):
     style = 'normal'
     color = '#c69a15'
@@ -162,7 +162,7 @@ class SetVarsGui(NodeGUI):
             }
 
 
-
+@node_gui(SetVar_Node)
 class SetVarGui(NodeGUI):
     input_widget_classes = {
         'varname': inp_widgets.Builder.str_line_edit(),
@@ -181,7 +181,7 @@ class SetVarGui(NodeGUI):
         self.input_widgets[self.node.inputs[-2]] = {'name': 'varname', 'pos': 'besides'}
         self.input_widgets[self.node.inputs[-1]] = {'name': 'val', 'pos': 'besides'}
 
-
+@node_gui(GetVar_Node)
 class GetVarGui(NodeGUI):
     input_widget_classes = {
         'varname': inp_widgets.Builder.str_line_edit(),
@@ -190,12 +190,3 @@ class GetVarGui(NodeGUI):
         0: {'name': 'varname', 'pos': 'besides'}
     }
     color = '#c69a15'
-
-
-export_guis([
-    GetVarGui,
-    ResultGui,
-    ValGui,
-    SetVarGui,
-    SetVarsGui,
-])

--- a/ryven-editor/ryven/main/packages/built_in/nodes.py
+++ b/ryven-editor/ryven/main/packages/built_in/nodes.py
@@ -1,7 +1,6 @@
-from ryven.node_env import *
-guis = import_guis(__file__)
-import ryvencore as rc
-
+from ryvencore import Node, NodeInputType, NodeOutputType, Data
+from ryven.node_env import export_nodes
+from ryven.gui_env import on_gui_load
 
 class NodeBase(Node):
     def have_gui(self):
@@ -17,7 +16,6 @@ class NodeBase(Node):
         return self.vars_addon().var(self.flow, var_name).set(val)
 
 
-
 class GetVar_Node(NodeBase):
     """Gets the value of a script variable"""
 
@@ -27,10 +25,7 @@ class GetVar_Node(NodeBase):
     init_inputs = [
         NodeInputType(),
     ]
-    init_outputs = [
-        NodeOutputType(label='val')
-    ]
-    GUI = guis.GetVarGui
+    init_outputs = [NodeOutputType(label='val')]
 
     def __init__(self, params):
         super().__init__(params)
@@ -45,7 +40,6 @@ class GetVar_Node(NodeBase):
 
     def update_event(self, input_called=-1):
         if self.input(0).payload != self.var_name:
-
             if self.var_name != '':  # disconnect old var val update connection
                 self.vars_addon().unsubscribe(self, self.var_name, self.var_val_changed)
 
@@ -69,7 +63,6 @@ class Result_Node(NodeBase):
     init_inputs = [
         NodeInputType(type_='data'),
     ]
-    GUI = guis.ResultGui
 
     def __init__(self, params):
         super().__init__(params)
@@ -96,14 +89,12 @@ class Val_Node(NodeBase):
     init_outputs = [
         NodeInputType(type_='data'),
     ]
-    GUI = guis.ValGui
 
     def __init__(self, params):
         super().__init__(params)
 
         self.display_title = ''
         self.val = Data()
-
 
     def place_event(self):
         self.update()
@@ -115,9 +106,7 @@ class Val_Node(NodeBase):
         return self.input(0).payload if self.input(0) is not None else None
 
     def get_state(self):
-        return {
-            'val': self.val  # self.main_widget().get_val()
-        }
+        return {'val': self.val}  # self.main_widget().get_val()
 
     def set_state(self, data, version):
         self.val = data['val']
@@ -139,8 +128,6 @@ class SetVar_Node(NodeBase):
         NodeOutputType(type_='data', label='val'),
     ]
 
-    GUI = guis.SetVarGui
-
     def __init__(self, params):
         super().__init__(params)
 
@@ -154,15 +141,12 @@ class SetVar_Node(NodeBase):
             self.gui.actions['make passive'] = {'method': self.action_make_passive}
 
     def update_event(self, input_called=-1):
-
         if self.active and input_called == 0:
-
             if self.set_var_val(self.input(1).payload, self.input(2).payload):
                 self.set_output_val(1, self.input(2))
             self.exec_output(0)
 
         elif not self.active:
-
             self.var_name = self.input(0).payload
             if self.set_var_val(self.input(0).payload, self.input(1).payload):
                 self.set_output_val(0, Data(self.get_var_val(self.var_name)))
@@ -200,7 +184,6 @@ class SetVarsPassive_Node(NodeBase):
     title = 'set vars passive'
     init_inputs = []
     init_outputs = []
-    GUI = guis.SetVarsGui
 
     def __init__(self, params):
         super().__init__(params)
@@ -219,8 +202,8 @@ class SetVarsPassive_Node(NodeBase):
             self.gui.rebuild_remove_actions()
 
     def remove_var_input(self, number):
-        self.delete_input((number-1)*2)
-        self.delete_input((number-1)*2)
+        self.delete_input((number - 1) * 2)
+        self.delete_input((number - 1) * 2)
         self.num_vars -= 1
         # self.rebuild_remove_actions()
 
@@ -246,7 +229,6 @@ class SetVarsPassive_Node(NodeBase):
     #         }
 
     def update_event(self, input_called=-1):
-
         var_names = [self.input(i).payload for i in range(0, len(self.inputs), 2)]
         values = [self.input(i).payload for i in range(1, len(self.inputs), 2)]
 
@@ -260,10 +242,10 @@ class SetVarsPassive_Node(NodeBase):
         self.num_vars = data['num vars']
 
 
-export_nodes([
-    SetVar_Node,
-    GetVar_Node,
-    Val_Node,
-    Result_Node,
-    SetVarsPassive_Node
-])
+nodes = [SetVar_Node, GetVar_Node, Val_Node, Result_Node, SetVarsPassive_Node]
+
+export_nodes(nodes)
+
+@on_gui_load
+def load_gui():
+    from . import gui

--- a/ryven-editor/ryven/main/packages/built_in/nodes.py
+++ b/ryven-editor/ryven/main/packages/built_in/nodes.py
@@ -1,6 +1,5 @@
 from ryvencore import Node, NodeInputType, NodeOutputType, Data
-from ryven.node_env import export_nodes
-from ryven.gui_env import on_gui_load
+from ryven.node_env import export_nodes, on_gui_load
 
 class NodeBase(Node):
     def have_gui(self):

--- a/ryven-editor/ryven/main/packages/gui_env.py
+++ b/ryven-editor/ryven/main/packages/gui_env.py
@@ -13,7 +13,6 @@ from ryvencore import Data, Node, serialize, deserialize
 from ryvencore.InfoMsgs import InfoMsgs
 from ryven.main.utils import in_gui_mode
 
-__gui_loaders: list = []
 __explicit_nodes: set = set() # for protection against setting the gui twice on the same node
 
 def init_node_guis_env():
@@ -49,29 +48,10 @@ def export_guis(guis: [Type[NodeGUI]]):
     GuiClassesRegistry.exported_guis_sources.append(gui_sources)
 
 
-def load_current_guis():
-    """
-    Calls the functions registered via `~ryven.main.gui_env.on_gui_load`.
-    """
-    if not in_gui_mode():
-        return
-    for func in __gui_loaders:
-        func()
-    __gui_loaders.clear()
-
-
-def on_gui_load(func):
-    """
-    Defers a parameterless function to be called for package loading when
-    the GUIs are loaded.
-    """
-    if in_gui_mode():
-        __gui_loaders.append(func)
-
-
 def node_gui(node_cls: Type[Node]):
     """
-    Registers a node widget as the GUI for a specific node.
+    Registers a node gui for a node class. The gui of a node is inherited to its sub-classes,
+    but can be overridden by specifying a new gui for the sub-class.
     """
     if not issubclass(node_cls, Node):
         raise Exception(f"{node_cls} is not of type {Node}")

--- a/ryven-editor/ryven/main/packages/gui_env.py
+++ b/ryven-editor/ryven/main/packages/gui_env.py
@@ -51,7 +51,7 @@ def export_guis(guis: [Type[NodeGUI]]):
 
 def load_current_guis():
     """
-    Calls the functions registered via on_gui_load.
+    Calls the functions registered via `~ryven.main.gui_env.on_gui_load`.
     """
     if not in_gui_mode():
         return
@@ -61,6 +61,10 @@ def load_current_guis():
 
 
 def on_gui_load(func):
+    """
+    Defers a parameterless function to be called for package loading when
+    the GUIs are loaded.
+    """
     if in_gui_mode():
         __gui_loaders.append(func)
 

--- a/ryven-editor/ryven/main/packages/node_env.py
+++ b/ryven-editor/ryven/main/packages/node_env.py
@@ -110,15 +110,13 @@ class NodesEnvRegistry:
     @classmethod
     # should be -> tuple[list[type[Node]], list[type[Data]] in 3.9+
     # should be result: tuple[list[type[Node]], list[type[Data]]] in 3.9+
-    def consume_last_exported_package(cls) -> Tuple[List[Type[Node]], List[Type[Node]]]:
-        result: Tuple[List[Type[Node]], List[Type[Node]]] = ([], [])
+    def consume_last_exported_package(cls) -> Tuple[List[Type[Node]], List[Type[Data]]]:
         """Consumes the last exported package"""
+        result: Tuple[List[Type[Node]], List[Type[Data]]] = ([], [])
         node_types, data_types = result
         for nodes, data in cls.last_exported_package:
-            for n in nodes:
-                node_types.append(n)
-            for d in data:
-                data_types.append(d)
+            node_types.extend(nodes)
+            data_types.extend(data)
         cls.last_exported_package.clear()
         return result
 

--- a/ryven-editor/ryven/main/packages/node_env.py
+++ b/ryven-editor/ryven/main/packages/node_env.py
@@ -10,8 +10,6 @@ from ryven.main.packages.nodes_package import load_from_file, NodesPackage
 
 from ryvencore import Node, NodeInputType, NodeOutputType, Data, serialize, deserialize
 
-import inspect
-
 
 def init_node_env():
     # Note 1:
@@ -34,6 +32,7 @@ def init_node_env():
         import ryvencore_qt
 
 
+# LEAVING THIS HERE FOR LEGACY PURPOSES
 def import_guis(origin_file: str, gui_file_name='gui.py'):
     """
     Import all exported GUI classes from gui_file_name with respect to the origin_file location.
@@ -114,12 +113,12 @@ class NodesEnvRegistry:
     def consume_last_exported_package(cls) -> Tuple[List[Type[Node]], List[Type[Node]]]:
         result: Tuple[List[Type[Node]], List[Type[Node]]] = ([], [])
         """Consumes the last exported package"""
-        r_nodes, d_nodes = result
+        node_types, data_types = result
         for nodes, data in cls.last_exported_package:
             for n in nodes:
-                r_nodes.append(n)
+                node_types.append(n)
             for d in data:
-                d_nodes.append(d)
+                data_types.append(d)
         cls.last_exported_package.clear()
         return result
 
@@ -153,13 +152,6 @@ def export_nodes(node_types: [Type[Node]], data_types: [Type[Data]] = None):
     nodes_datas = (node_types, data_types)
     metadata[pkg_name] = nodes_datas
     NodesEnvRegistry.last_exported_package.append(nodes_datas)
-
-    if os.environ['RYVEN_MODE'] == 'gui':
-        # store node sources for code inspection
-        from ryven.gui.code_editor.codes_storage import register_node_type
-
-        for node_type in node_types:
-            register_node_type(node_type)
 
 
 def export_sub_nodes(

--- a/ryven-editor/ryven/main/utils.py
+++ b/ryven-editor/ryven/main/utils.py
@@ -7,6 +7,10 @@ from os.path import normpath, join, dirname, abspath, expanduser
 import pathlib
 from typing import Union, Optional
 from packaging.version import Version
+from os import environ
+
+def in_gui_mode()->bool:
+    return environ['RYVEN_MODE'] == 'gui'
 
 
 def read_project(project_path: Union[str, pathlib.Path]) -> dict:

--- a/ryven-editor/ryven/main/utils.py
+++ b/ryven-editor/ryven/main/utils.py
@@ -9,7 +9,7 @@ from typing import Union, Optional
 from packaging.version import Version
 from os import environ
 
-def in_gui_mode()->bool:
+def in_gui_mode() -> bool:
     return environ['RYVEN_MODE'] == 'gui'
 
 


### PR DESCRIPTION
This PR introduces a new way to assign Node GUIs to Nodes. Specifically:

- It introduces a decorator called `node_gui` which accepts a Node as a parameter. Assigning a gui to a node happens in the `gui.py` file and not the `nodes.py`, allowing for IDE hinting and deprecating the need for the `import_guis` and `export_guis` functions.
- Introduces a `on_gui_load` function which can be applied to any function in the imported `nodes.py` file.  This function will then be called after package loading in `import_nodes_package`.
- ~~Adds a `api.py` file in the ryven folder. Might not be needed, but thought it was a good idea.~~ Bad idea, read the conversation for details.

The `built_in` package and the `pkg_test` package (which has `linalg` and `std` subpackages) have been changed to use this new utility. The older `linalg` and `std` packages haven't been altered and are working with the "deprecated" functions.

CC: these ideas were first discussed in #171 as a result of investigating sub-packages