### PR TITLE
PySide 6 Update

### DIFF
--- a/ryven-editor/ryven/example_nodes/std/gui.py
+++ b/ryven-editor/ryven/example_nodes/std/gui.py
@@ -197,7 +197,7 @@ class CheckpointNodeGui(DualNodeBaseGui):
                 {'method': self.remove_output, 'data': i}
 
 
-class ButtonNode_MainWidget(QPushButton, NodeMainWidget):
+class ButtonNode_MainWidget(NodeMainWidget, QPushButton):
 
     def __init__(self, params):
         NodeMainWidget.__init__(self, params)

--- a/ryven-editor/ryven/gui/main_window.py
+++ b/ryven-editor/ryven/gui/main_window.py
@@ -400,7 +400,7 @@ CONTROLS
 
     def on_save_scene_pic_whole_triggered(self):
         """Saves a picture of the whole currently visible scene."""
-        if len(self.session_gui.flows) == 0:
+        if len(self.core_session.flows) == 0:
             return
 
         file_path = QFileDialog.getSaveFileName(self, 'select file', '', 'PNG(*.png)')[0]

--- a/ryven-editor/ryven/gui/startup_dialog/StartupDialog.py
+++ b/ryven-editor/ryven/gui/startup_dialog/StartupDialog.py
@@ -71,7 +71,8 @@ class ElideLabel(QLabel):
 
     def sizeHint(self):
         hint = self.fontMetrics().boundingRect(self.text()).size()
-        l, t, r, b = self.getContentsMargins()
+        c_margins = self.contentsMargins()
+        l, t, r, b = c_margins.left(), c_margins.top(), c_margins.right(), c_margins.bottom()
         margin = self.margin() * 2
         return QSize(
             min(100, hint.width()) + l + r + margin,
@@ -83,7 +84,8 @@ class ElideLabel(QLabel):
         opt = QStyleOptionFrame()
         self.initStyleOption(opt)
         self.style().drawControl(QStyle.CE_ShapedFrame, opt, qp, self)
-        l, t, r, b = self.getContentsMargins()
+        c_margins = self.contentsMargins()
+        l, t, r, b = c_margins.left(), c_margins.top(), c_margins.right(), c_margins.bottom()
         margin = self.margin()
         try:
             # since Qt >= 5.11

--- a/ryvencore-qt/ryvencore_qt/src/flows/FlowView.py
+++ b/ryvencore-qt/ryvencore_qt/src/flows/FlowView.py
@@ -517,7 +517,7 @@ class FlowView(GUIBase, QGraphicsView):
             self._zoom_data['delta'] += y_delta
 
             if self._zoom_data['delta'] * y_delta < 0:
-                self._zoom_data['delta'] = y_delta()
+                self._zoom_data['delta'] = y_delta
 
             anim = QTimeLine(100, self)
             anim.setUpdateInterval(10)

--- a/ryvencore-qt/ryvencore_qt/src/flows/FlowView.py
+++ b/ryvencore-qt/ryvencore_qt/src/flows/FlowView.py
@@ -31,11 +31,16 @@ from qtpy.QtWidgets import (
     QShortcut,
     QMenu,
     QGraphicsItem,
-    QUndoStack,
     QPushButton,
     QHBoxLayout,
     QWidget,
 )
+
+# for compatibility between qt5 and qt6
+try:
+    from qtpy.QtGui import QUndoStack
+except ImportError:
+    from qtpy.QtWidgets import QUndoStack
 
 from ryvencore.Flow import Flow
 from ryvencore.Node import Node
@@ -254,13 +259,11 @@ class FlowView(GUIBase, QGraphicsView):
         menu_layout_widget.layout().addWidget(menu_button)
 
         def menu_button_clicked():
-            point = self._menu_layout_proxy.scenePos()
-            view_pos = self.mapFromScene(point.toPoint())
-            # apply offset after
-            global_pos = self.viewport().mapToGlobal(
-                view_pos) + QPoint(8, self._menu_layout_proxy.widget().height()
-            ) 
-            self._menu.exec_(global_pos)
+            # prob not entirely correct, since menu is part of a layout
+            # but since it's the first item, it's the same
+            menu_pos = self._menu_button.pos()
+            menu_pos = self.mapToGlobal(menu_pos) + QPoint(8, self._menu_button.height() + 10)
+            self._menu.exec_(menu_pos)
 
         menu_button.clicked.connect(menu_button_clicked)
 
@@ -506,13 +509,15 @@ class FlowView(GUIBase, QGraphicsView):
         if event.modifiers() & Qt.ControlModifier:
             event.accept()
 
-            self._zoom_data['viewport pos'] = event.posF()
-            self._zoom_data['scene pos'] = pointF_mapped(self.mapToScene(event.pos()), event.posF())
+            view_pos = event.position()
+            self._zoom_data['viewport pos'] = view_pos
+            self._zoom_data['scene pos'] = self.mapToScene(view_pos.toPoint())
 
-            self._zoom_data['delta'] += event.delta()
+            y_delta = event.angleDelta().y()
+            self._zoom_data['delta'] += y_delta
 
-            if self._zoom_data['delta'] * event.delta() < 0:
-                self._zoom_data['delta'] = event.delta()
+            if self._zoom_data['delta'] * y_delta < 0:
+                self._zoom_data['delta'] = y_delta()
 
             anim = QTimeLine(100, self)
             anim.setUpdateInterval(10)

--- a/ryvencore-qt/ryvencore_qt/src/flows/connections/ConnectionAnimation.py
+++ b/ryvencore-qt/ryvencore_qt/src/flows/connections/ConnectionAnimation.py
@@ -4,7 +4,8 @@ from enum import Enum
 from qtpy.QtCore import (
     QTimeLine, 
     QPropertyAnimation, 
-    QParallelAnimationGroup, 
+    QParallelAnimationGroup,
+    QEasingCurve, 
 )
 from qtpy.QtGui import (
     QPen,
@@ -43,12 +44,13 @@ class ConnPathItemsAnimation(QGraphicsObject):
         self.between = between
         self.speed = speed
         self.visible_items = []
+        self.__visible_flag = True
         
         self.setParentItem(self.connection)
         
         self.timeline = QTimeLine()
         self.timeline.setFrameRange(0, frames)
-        self.timeline.setCurveShape(QTimeLine.LinearCurve)
+        self.timeline.setEasingCurve(QEasingCurve.Type.Linear)
         self.timeline.valueChanged.connect(self._update_items)
         self.timeline.setLoopCount(0)
 
@@ -88,11 +90,16 @@ class ConnPathItemsAnimation(QGraphicsObject):
             self.recompute()
 
     def recompute(self):
-        for item in self.items:
-            item.setVisible(False)
+        
+        if self.__visible_flag:
+            for item in self.items:
+                item.setVisible(False)
+            self.__visible_flag = False
 
         if self.timeline.state() == QTimeLine.State.NotRunning:
             return
+        
+        self.__visible_flag = True
 
         path_len = self.connection.path().length()
         num_points = max(3, min(self.connection.num_dots, int(path_len / self.between)))
@@ -162,7 +169,17 @@ class ConnPathItemsAnimationScaled:
 
         self.to_scalar_group.finished.connect(self._on_scalar_ended)
         self.to_zero_group.finished.connect(self._on_zero_ended)
-        
+    
+    def start(self):
+        if (self.state == ConnPathItemsAnimationScaled.State.NOT_RUNNING or 
+            self.state == ConnPathItemsAnimationScaled.State.TO_ZERO):
+            self.toggle()
+    
+    def stop(self):
+        if (self.state == ConnPathItemsAnimationScaled.State.RUNNING or
+            self.state == ConnPathItemsAnimationScaled.State.TO_SCALE):
+            self.toggle()
+            
     def toggle(self):
         if self.state == ConnPathItemsAnimationScaled.State.NOT_RUNNING:
             self._run_scalar()
@@ -180,7 +197,7 @@ class ConnPathItemsAnimationScaled:
             self._run_scalar()
             self.state = ConnPathItemsAnimationScaled.State.TO_SCALE
     
-    def _stop(self):
+    def force_stop(self):
         self.to_zero_group.stop()
         self.to_scalar_group.stop()
     

--- a/ryvencore-qt/ryvencore_qt/src/flows/node_list_widget/NodeListWidget.py
+++ b/ryvencore-qt/ryvencore_qt/src/flows/node_list_widget/NodeListWidget.py
@@ -151,10 +151,10 @@ class NodeListWidget(QWidget):
             # removes whitespace and escapes all special regex chars
             new_search = escape(search.strip())
             # regex that enforces the text starts with <new_search>
-            self.pack_proxy_model.setFilterRegExp(f'^{new_search}')
+            self.pack_proxy_model.setFilterRegularExpression(f'^{new_search}')
             self.pack_tree.expandAll()
         else:
-            self.pack_proxy_model.setFilterRegExp('')
+            self.pack_proxy_model.setFilterRegularExpression('')
             self.pack_tree.collapseAll()
 
     def make_nodes_current(self, pack_nodes, pkg_name: str):

--- a/ryvencore-qt/ryvencore_qt/src/flows/nodes/NodeInspector.py
+++ b/ryvencore-qt/ryvencore_qt/src/flows/nodes/NodeInspector.py
@@ -4,9 +4,11 @@ from qtpy.QtWidgets import (
     QWidget, 
     QVBoxLayout, 
     QLabel, 
-    QTextEdit, 
+    QTextEdit,
+    QSplitter,
 )
 
+from qtpy.QtCore import Qt
 from ryvencore import Node
 
 from .WidgetBaseClasses import NodeInspectorWidget
@@ -42,9 +44,9 @@ class InspectorView(QWidget):
             return
 
         if self.inspector_widget:
-            self.inspector_widget.unload()
             self.inspector_widget.setVisible(False)
             self.inspector_widget.setParent(None)
+            self.inspector_widget.unload()
             
         self.node = None
         self.inspector_widget = None
@@ -53,8 +55,8 @@ class InspectorView(QWidget):
             self.node = node
             self.inspector_widget = self.node.gui.inspector_widget
             self.layout().addWidget(self.inspector_widget)
-            self.inspector_widget.setVisible(True)
             self.inspector_widget.load()
+            self.inspector_widget.setVisible(True)
 
 
 class NodeInspectorDefaultWidget(NodeInspectorWidget, QWidget):
@@ -71,6 +73,7 @@ class NodeInspectorDefaultWidget(NodeInspectorWidget, QWidget):
         QWidget.__init__(self)
         NodeInspectorWidget.__init__(self, params)
 
+        self.child = child
         self.setLayout(QVBoxLayout())
 
         self.title_label: QLabel = QLabel()
@@ -78,10 +81,16 @@ class NodeInspectorDefaultWidget(NodeInspectorWidget, QWidget):
             f'<h2>{self.node.title}</h2> '
             f'<h4>id: {self.node.global_id}, pyid: {id(self.node)}</h4>'
         )
+        # title
         self.layout().addWidget(self.title_label)
-
+        
+        # content splitter
+        self.content_splitter = QSplitter()
+        self.content_splitter.setOrientation(Qt.Orientation.Vertical)
+        self.layout().addWidget(self.content_splitter)
+        
         if child:
-            self.layout().addWidget(child)
+            self.content_splitter.addWidget(child)
 
         desc = self.node.__doc__ if self.node.__doc__ and self.node.__doc__ != "" else "No description given"
         bbt = NodeInspectorDefaultWidget._big_bold_text
@@ -99,4 +108,14 @@ class NodeInspectorDefaultWidget(NodeInspectorWidget, QWidget):
 </html>
         """)
     
-        self.layout().addWidget(self.description_area)
+        self.content_splitter.addWidget(self.description_area)
+    
+    def load(self):
+        super().load()
+        if self.child:
+            self.child.load()
+    
+    def unload(self):
+        if self.child:
+            self.child.unload()
+        super().unload()


### PR DESCRIPTION
- PySide6 works without breaking PySide2. ~~Probably works the same for PyQt5, PyQt6, but haven't tested.~~ Not Supported
- Scaled connection path animation can now start / stop and was slightly optimized
- Fixed the bug when taking a full view screenshot
- `NodeInspectorDefaultWidget` updates and fixes (splitter for content, load unload for child if it exists)

If you check it out and see no problems, I can also make pyside6 the default.

This can also help close #138